### PR TITLE
Update to the new scheduling syntax

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { version = "1.0.0-rc1" }
+spacetimedb = { version = "1.0.0-rc2" }
 log = "0.4"
 rand = "0.8.5"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -87,7 +87,6 @@ pub struct MoveAllPlayersTimer {
     #[primary_key]
     #[auto_inc]
     scheduled_id: u64,
-    #[scheduled_at]
     scheduled_at: spacetimedb::ScheduleAt,
 }
 
@@ -96,7 +95,6 @@ pub struct SpawnFoodTimer {
     #[primary_key]
     #[auto_inc]
     scheduled_id: u64,
-    #[scheduled_at]
     scheduled_at: spacetimedb::ScheduleAt,
 }
 
@@ -105,7 +103,6 @@ pub struct CircleDecayTimer {
     #[primary_key]
     #[auto_inc]
     scheduled_id: u64,
-    #[scheduled_at]
     scheduled_at: spacetimedb::ScheduleAt,
 }
 


### PR DESCRIPTION
The attribute no longer exist, we now either infer the name automatically or specify it within the `table(scheduled(at = ...))` attribute instead.